### PR TITLE
fix(badge): support github accounts with no set name

### DIFF
--- a/api/github/badge-issue.js
+++ b/api/github/badge-issue.js
@@ -39,11 +39,17 @@ module.exports = async (req, res) => {
     .then((response) => response.json())
     .catch((error) => res.status(401).json({ error: error.message }));
 
-  if (!user || !user.name) {
+  if (!user) {
     return res.status(401).json({
-      error: "Could not retrieve GitHub user's name.",
+      error: "Could not retrieve GitHub user.",
     });
   }
+
+  // Acclaim API requires first and last name, but GitHub only has one user name
+  // default to using GitHub username for both badge first and last name
+  const name = user.name || user.login;
+  const firstName = name.trim().split(" ")[0];
+  const lastName = name.trim().split(" ").reverse()[0];
 
   // issue badge
   const badgesResponse = await fetch(
@@ -59,8 +65,8 @@ module.exports = async (req, res) => {
       body: JSON.stringify({
         recipient_email: email,
         badge_template_id: badgeConfig[badge].acclaimTemplate,
-        issued_to_first_name: user.name.trim().split(" ")[0],
-        issued_to_last_name: user.name.trim().split(" ").reverse()[0],
+        issued_to_first_name: firstName,
+        issued_to_last_name: lastName,
         issued_at: new Date().toISOString(),
       }),
     }

--- a/src/components/MyBadges/MyBadges.js
+++ b/src/components/MyBadges/MyBadges.js
@@ -48,7 +48,7 @@ const MyBadges = () => {
       {badges && badges.length > 0 && (
         <Row>
           {badges.map((badge, i) => (
-            <Column key={i} colMd={3} colLg={3} noGutterMdLeft>
+            <Column key={i} colSm={2} colMd={3} colLg={3} noGutterMdLeft>
               <ArticleCard
                 subTitle={
                   badge.state.charAt(0).toUpperCase() + badge.state.slice(1)


### PR DESCRIPTION
Fixes this error where the GitHub user account had not set a name yet here: https://github.com/settings/profile

![image](https://user-images.githubusercontent.com/1691245/92487295-ae5ca000-f1b2-11ea-807e-bd7bf9b9d455.png)
